### PR TITLE
Add Contacts Schema

### DIFF
--- a/data/bootstrap/18_contacts.yml
+++ b/data/bootstrap/18_contacts.yml
@@ -1,0 +1,196 @@
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: OrganizationContact
+  data:
+    # Manufacturers
+    - name: John Smith
+      title: Account Manager
+      email: john.smith@cisco.com
+      phone: 123-456-7890
+      organization: Cisco
+    - name: Jim Halpert
+      title: Support Manager
+      email: jim.halpert@cisco.com
+      phone: 123-456-7891
+      organization: Cisco
+    - name: Dwight Schrute
+      title: Sales Engineer
+      email: dwight.schrute@juniper.net
+      phone: 123-456-7892
+      organization: Juniper
+    - name: Ryan Howard
+      title: Product Manager
+      email: ryan.howard@arista.com
+      phone: 123-456-7893
+      organization: Arista
+    - name: Andy Bernard
+      title: Regional Director
+      email: andy.bernard@dell.com
+      phone: 123-456-7894
+      organization: Dell
+    - name: Gabe Lewis
+      title: Compliance Officer
+      email: gabe.lewis@fortinet.com
+      phone: 123-456-7895
+      organization: Fortinet
+    - name: Robert California
+      title: Security Consultant
+      email: robert.california@checkpoint.com
+      phone: 123-456-7896
+      organization: Check Point
+
+    # Providers
+    - name: Jan Levinson
+      title: VP of Sales
+      email: jan.levinson@aws.amazon.com
+      phone: 123-456-7900
+      organization: AWS
+    - name: David Wallace
+      title: Cloud Solution Architect
+      email: david.wallace@microsoft.com
+      phone: 123-456-7901
+      organization: Azure
+    - name: Karen Filippelli
+      title: Regional Manager
+      email: karen.filippelli@google.com
+      phone: 123-456-7902
+      organization: Google Cloud
+    - name: Roy Anderson
+      title: Facility Manager
+      email: roy.anderson@equinix.com
+      phone: 123-456-7903
+      organization: Equinix
+    - name: Stanley Hudson
+      title: Sales Representative
+      email: stanley.hudson@lumen.com
+      phone: 123-456-7904
+      organization: Lumen
+    - name: Todd Packer
+      title: Account Executive
+      email: todd.packer@zayo.com
+      phone: 123-456-7905
+      organization: Zayo
+    - name: Charles Miner
+      title: VP of North East
+      email: charles.miner@verizon.com
+      phone: 123-456-7906
+      organization: Verizon Business
+    - name: Danny Cordray
+      title: Traveling Salesman
+      email: danny.cordray@att.com
+      phone: 123-456-7907
+      organization: AT&T Services
+
+    # Customers
+    - name: Michael Scott
+      title: Regional Manager
+      email: michael.scott@customer1.com
+      phone: 123-456-8001
+      organization: Customer 1
+    - name: Darryl Philbin
+      title: IT Operations Manager
+      email: darryl.philbin@customer1.com
+      phone: 123-456-8002
+      organization: Customer 1
+    - name: Pam Beesly
+      title: Office Administrator
+      email: pam.beesly@customer2.com
+      phone: 123-456-8003
+      organization: Customer 2
+    - name: Angela Martin
+      title: Head of Accounting
+      email: angela.martin@customer3.com
+      phone: 123-456-8004
+      organization: Customer 3
+    - name: Oscar Martinez
+      title: Senior Accountant
+      email: oscar.martinez@customer4.com
+      phone: 123-456-8005
+      organization: Customer 4
+    - name: Kevin Malone
+      title: Accountant
+      email: kevin.malone@customer5.com
+      phone: 123-456-8006
+      organization: Customer 5
+    - name: Bob Vance
+      title: Owner
+      email: bob.vance@customer5.com
+      phone: 123-456-8007
+      organization: Customer 5
+    - name: Kelly Kapoor
+      title: Customer Service Rep
+      email: kelly.kapoor@customer6.com
+      phone: 123-456-8008
+      organization: Customer 6
+    - name: Toby Flenderson
+      title: HR Representative
+      email: toby.flenderson@customer7.com
+      phone: 123-456-8009
+      organization: Customer 7
+    - name: Creed Bratton
+      title: Quality Assurance
+      email: creed.bratton@customer8.com
+      phone: 123-456-8010
+      organization: Customer 8
+    - name: Meredith Palmer
+      title: Supplier Relations
+      email: meredith.palmer@customer9.com
+      phone: 123-456-8011
+      organization: Customer 9
+    - name: Phyllis Lapin
+      title: Sales Representative
+      email: phyllis.lapin@customer10.com
+      phone: 123-456-8012
+      organization: Customer 10
+    - name: Nellie Bertram
+      title: Special Projects Manager
+      email: nellie.bertram@customer11.com
+      phone: 123-456-8013
+      organization: Customer 11
+    - name: Pete Miller
+      title: Customer Support
+      email: pete.miller@customer12.com
+      phone: 123-456-8014
+      organization: Customer 12
+    - name: Clark Green
+      title: Junior Sales
+      email: clark.green@customer13.com
+      phone: 123-456-8015
+      organization: Customer 13
+    - name: Erin Hannon
+      title: IT Support Specialist
+      email: erin.hannon@customer14.com
+      phone: 123-456-8016
+      organization: Customer 14
+    - name: Jo Bennett
+      title: CEO
+      email: jo.bennett@customer15.com
+      phone: 123-456-8017
+      organization: Customer 15
+    - name: Deangelo Vickers
+      title: Executive Manager
+      email: deangelo.vickers@customer16.com
+      phone: 123-456-8018
+      organization: Customer 16
+    - name: Holly Flax
+      title: HR Director
+      email: holly.flax@customer17.com
+      phone: 123-456-8019
+      organization: Customer 17
+    - name: David Brent
+      title: General Manager
+      email: david.brent@customer18.com
+      phone: 123-456-8020
+      organization: Customer 18
+    - name: Mose Schrute
+      title: Facilities
+      email: mose.schrute@customer19.com
+      phone: 123-456-8021
+      organization: Customer 19
+    - name: John Doe
+      title: Consultant
+      email: john.doe@customer20.com
+      phone: 123-456-8022
+      organization: Customer 20

--- a/menu/menu.yml
+++ b/menu/menu.yml
@@ -28,6 +28,13 @@ spec:
             label: Customers
             kind: OrganizationCustomer
             icon: "mdi:account-group"
+
+          - namespace: Organization
+            name: Contact
+            label: Contacts
+            kind: OrganizationContact
+            icon: "mdi:user"
+
     # ===================== LOCATION =====================
     - namespace: Location
       name: Generic

--- a/schemas/base/organization.yml
+++ b/schemas/base/organization.yml
@@ -35,6 +35,8 @@ nodes:
     namespace: Organization
     description: Device Manufacturer
     icon: mdi:domain
+    inherit_from:
+      - OrganizationGeneric
     include_in_menu: true
     menu_placement: OrganizationGeneric
     human_friendly_id:
@@ -42,15 +44,6 @@ nodes:
     order_by:
       - name__value
     display_label: "{{name__value}}"
-    attributes:
-      - name: name
-        kind: Text
-        unique: true
-        order_weight: 1000
-      - name: description
-        kind: Text
-        optional: true
-        order_weight: 1200
     relationships:
       - name: device_type
         peer: DcimDeviceType

--- a/schemas/extensions/contacts/contact.yaml
+++ b/schemas/extensions/contacts/contact.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: Contact
+    namespace: Organization
+    description: "A contact is a person or a group associated with an object."
+    label: "Contact"
+    include_in_menu: false
+    icon: "mdi:user"
+    display_label: "{{ name__value }}"
+    order_by:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        unique: false
+        order_weight: 1000
+      - name: title
+        kind: Text
+        optional: true
+        order_weight: 1100
+      - name: phone
+        label: Phone
+        kind: Text
+        optional: true
+        order_weight: 1200
+      - name: email
+        label: E-mail
+        kind: Email
+        optional: true
+        order_weight: 1300
+      - name: address
+        label: Address
+        kind: Text
+        optional: true
+        order_weight: 1400
+      - name: link
+        label: Link
+        kind: URL
+        optional: true
+        order_weight: 1500
+      - name: description
+        kind: Text
+        optional: true
+        order_weight: 1600
+    relationships:
+      - name: organization
+        peer: OrganizationGeneric
+        cardinality: one
+        kind: Attribute
+        optional: true
+        order_weight: 2000
+      # - name: location
+      #   peer: LocationGeneric
+      #   cardinality: many
+      #   kind: Attribute
+      #   optional: true
+      #   order_weight: 2100
+      - name: tags
+        peer: BuiltinTag
+        cardinality: many
+        kind: Attribute
+        optional: true
+        order_weight: 3000
+
+extensions:
+  nodes:
+    - kind: OrganizationGeneric
+      relationships:
+        - name: contacts
+          peer: OrganizationContact
+          optional: true
+          cardinality: many
+    # - kind: LocationGeneric
+    #   relationships:
+    #     - name: contacts
+    #       peer: OrganizationContact
+    #       optional: true
+    #       cardinality: many


### PR DESCRIPTION
This pull request introduces a new contact management feature for organizations, including schema definitions, sample data, and menu integration. The changes enable storing and displaying contact information associated with organizations, manufacturers, providers, and customers.

**Contact Management Feature**

* Added a new `Contact` node schema under the `Organization` namespace, defining attributes (name, title, phone, email, etc.) and relationships to organizations and tags. (`schemas/extensions/contacts/contact.yaml`)
* Introduced a bootstrap data file with sample contacts for manufacturers, providers, and customers for initial setup and testing. (`data/bootstrap/18_contacts.yml`)

**Menu and Schema Integration**

* Updated the organization menu to include a "Contacts" section, making contacts accessible from the UI. (`menu/menu.yml`)
* Extended the organization schema to inherit from `OrganizationGeneric`, supporting integration of contacts and maintaining menu placement. (`schemas/base/organization.yml`)Add a Contacts schema.

For now I associated to just Organizations, but we could try something more advanced and allow contacts to be associated to other types of schemas.