### PR TITLE
fix: query validation, release flow, bootstrap cleanup (v0.2.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - "**"
     tags:
       - "v*"
+  pull_request:
 
 permissions:
   contents: read
@@ -26,14 +27,14 @@ jobs:
           uv sync
       - name: Run pre-commit hooks
         run: |
-          echo "🔍 Running pre-commit quality gates..."
           uv run prek run --all-files
-      - name: Verify pre-commit passed
-        run: |
-          echo "✅ All pre-commit checks passed!"
 
   tests:
     name: Testing plugin
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/tags/v')
     needs: code-qa
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ on:
       - "**"
     tags:
       - "v*"
-  pull_request:
 
 permissions:
   contents: read
@@ -31,10 +30,6 @@ jobs:
 
   tests:
     name: Testing plugin
-    if: >-
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/v')
     needs: code-qa
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -54,12 +49,8 @@ jobs:
           fetch-depth: 0
       - name: Attach HEAD to branch
         run: |
-          if [ -n "$GITHUB_HEAD_REF" ]; then
-            git checkout "$GITHUB_HEAD_REF"
-          else
-            BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's|origin/||' | xargs)
-            if [ -n "$BRANCH" ]; then git checkout "$BRANCH"; fi
-          fi
+          BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's|origin/||' | xargs)
+          if [ -n "$BRANCH" ]; then git checkout "$BRANCH"; fi
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
       - "**"
-  workflow_dispatch:
-    inputs:
-      create_release:
-        description: "Create GitHub Release from current version tag"
-        required: false
-        default: "true"
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -69,36 +65,8 @@ jobs:
         run: |
           uv run pytest -vv tests/smoke tests/unit --cov
 
-  bump:
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-    permissions:
-      contents: write
-    needs: tests
-    name: Bump version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip install uv
-          uv sync
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Bump version
-        run: uv run cz bump --yes || true
-      - name: Push commit and tag
-        run: git push && git push --tags
-
   release:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
     needs: tests
@@ -106,24 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-      - name: Get current version tag
-        id: version
-        run: |
-          pip install uv
-          uv sync
-          TAG="v$(uv run python -c 'import tomllib; print(tomllib.load(open(\"pyproject.toml\",\"rb\"))[\"project\"][\"version\"])')"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-      - name: Create GitHub release
+      - name: Create GitHub release from tag
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ steps.version.outputs.tag }}
-          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           generate_release_notes: true
   # document:
   #   if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,12 @@ jobs:
           fetch-depth: 0
       - name: Attach HEAD to branch
         run: |
-          BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's|origin/||' | xargs)
-          if [ -n "$BRANCH" ]; then git checkout "$BRANCH"; fi
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            git checkout "$GITHUB_HEAD_REF"
+          else
+            BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's|origin/||' | xargs)
+            if [ -n "$BRANCH" ]; then git checkout "$BRANCH"; fi
+          fi
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Attach HEAD to branch
+        run: |
+          BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's|origin/||' | xargs)
+          if [ -n "$BRANCH" ]; then git checkout "$BRANCH"; fi
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
         args:
           - --fix
           - --disable=MD013  # Line length - enforced at 120 chars (code/tables/headings excluded)
+          - --disable=MD024  # Duplicate headings - needed for CHANGELOG.md (Fix/Feat repeat across versions)
         exclude: ^(\.ai/|\.dev/|\.github/|docs/)
 
   # Security scanning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,17 +151,18 @@ Use scope to narrow the area: `schema`, `generator`, `template`, `check`, `trans
 
 ## Release Workflow
 
-Version bumping is **fully automatic**. On every merge to `main`, CI runs
-`cz bump --yes`, updates `pyproject.toml` and `CHANGELOG.md`, and pushes
-the new tag back to `main`. No manual steps needed.
+Most PRs (bug fixes, features, dependabot) are merged without any version bump.
+When you are ready to ship a release, create a dedicated release PR:
 
-To publish a **GitHub Release** (when you want to announce a version):
+```bash
+uv run invoke release        # bumps pyproject.toml, updates CHANGELOG.md, tags
+git push && git push --tags  # push branch + tag together
+```
 
-1. Go to **Actions → CI → Run workflow** on `main`
-2. CI reads the current version and creates the GitHub Release with
-   auto-generated release notes
+Open the PR and merge. CI detects the `v*` tag and creates the GitHub Release
+automatically with generated release notes.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
 
 ## Development Patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,28 @@
 # Changelog
+
+## v0.2.1 (2026-06-20)
+
+### Fix
+
+- query validation, CI release flow, and bootstrap cleanup
+- **query**: use inline fragment for name on ManagedGenericDevice in capability_guard
+
+## v0.2.0 (2026-06-20)
+
+### Feat
+
+- universal topology, graph tracing, schema cleanup, and release tooling
+
+## v0.1.5 (2025-12-10)
+
+### Fix
+
+- correct brace hierarchy in leaf.gql ServiceOSPF fragment
+
+## v0.1.3 (2025-08-27)
+
+## v0.1.2 (2025-08-06)
+
+## v0.1.1 (2025-07-18)
+
+## v0.1.0 (2025-05-08)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,6 @@ uv sync
 
 ### Branching
 
-Use the following branch naming convention:
-
 | Prefix | Purpose |
 | --- | --- |
 | `feat/` | New features |
@@ -80,36 +78,41 @@ uv run pytest tests/unit tests/smoke -v
 uv run pytest tests/integration -v
 ```
 
-## Versioning
-
-This project follows [Semantic Versioning](https://semver.org/).
-
-### Automatic version bumps
-
-Every merge to `main` triggers CI to:
-
-1. Run `cz bump --yes` — reads commits since last tag, determines bump level automatically
-2. Update `pyproject.toml` and `CHANGELOG.md`
-3. Commit and push the new tag to `main`
-
-**No manual version bumping.** Never edit `pyproject.toml` version by hand.
-
-### Publishing a GitHub Release
-
-Version bumps happen silently on every merge. A GitHub Release is published
-manually when you want to announce a version:
-
-1. Ensure all desired PRs are merged to `main`
-2. Go to **Actions → CI → Run workflow** (select `main` branch)
-3. CI reads the current version from `pyproject.toml` and creates the GitHub
-   Release with auto-generated release notes
-
-This keeps release noise low — dependabot and minor patches bump the version
-automatically; you publish a Release when it actually matters.
-
 ## Pull Requests
 
 - Target `main`
 - Keep PRs focused — one concern per PR
 - Ensure all CI checks pass before requesting review
 - Squash merge is preferred to keep `main` history clean
+
+## Versioning and Releases
+
+This project follows [Semantic Versioning](https://semver.org/).
+
+### Normal PRs — no version bump
+
+Bug fixes, features, and dependabot updates are merged without touching the
+version. Just write proper conventional commits and merge.
+
+### Release PR — when you want to ship
+
+When enough has accumulated and you want to publish a release, create a
+dedicated release branch:
+
+```bash
+git checkout -b release/vX.Y.Z
+uv run invoke release        # auto-detects bump level from commits since last tag
+                             # or: uv run invoke release --increment minor
+git push && git push --tags  # push branch AND tag together
+```
+
+Open a PR, merge it. CI detects the `v*` tag push and automatically:
+
+1. Runs tests
+2. Creates the GitHub Release with auto-generated release notes
+
+The tag is read directly from the pushed tag (`github.ref_name`) — it is always
+in sync with the `pyproject.toml` version because `invoke release` creates both
+from the same `cz bump` run.
+
+**Never edit `pyproject.toml` version by hand** — always use `invoke release`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "netutils>=1.8.0",
 ]
 name = "infrahub-demo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Design driven automation"
 readme = "README.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -641,7 +641,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-demo"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "infrahub-sdk", extra = ["all"] },


### PR DESCRIPTION
## Summary

- Fix GraphQL abstract type inline fragments (`capability_guard.gql`, `oob.gql`)
- Replace removed `CloudAutoScalingGroup` with `VirtCluster` + `node_pools`
- Recreate `queries/validation/lb.gql` starting from `OnpremLoadbalancer` directly
- Remove leftover deleted files from `.infrahub.yml`
- Comment out `rack_elevation` artifact
- Fix `TemplateDcimVirtualDevice` crash — remove from `loadbalancers` group (templates are not artifact targets)
- CI: tag-triggered release (`v*` push → tests → GitHub Release)
- Fix MD024 markdownlint false positive on `CHANGELOG.md` duplicate headings
- Add `CONTRIBUTING.md` with branching, commit, versioning, and release docs
- Bump version to 0.2.1

## Test plan

- [ ] CI passes
- [ ] After merge, confirm GitHub Release v0.2.1 is created automatically